### PR TITLE
Disainiparandus

### DIFF
--- a/disain/index.html
+++ b/disain/index.html
@@ -77,9 +77,9 @@
         <div id="collapseOne" class="collapse" role="tabpanel" aria-labelledby="methodIDCard" aria-expanded="false">
           <div class="block-hr hidden-xs"></div>
           <div class="white hidden-xs method-block-collapsible">
+             <p>Sisesta kaart lugejasse ja vajuta "Sisene"</p>
             <div class="row">
               <div class="col-md-6 col-sm-6 col-xs-6">
-                <p>Sisesta kaart lugejasse ja vajuta "Sisene"</p>
                 <button class="primary" type="button" name="button">Sisene</button>
               </div>
               <div class="col-md-6 col-sm-6 col-xs-6">


### PR DESCRIPTION
ID-kaardi kirjelduse tekst "Sisestage.." peaks olema method-block-collapsible paragrahv, aga on jäetud järgmise div-i sisse, mis on col-md-6 laiusega, seetõttu on tekstiblokk kitsam. Tõstsin teksti paragrahvi method-block-collapible alla. Samuti on ka mobiil-ID kirjelduse tekst.