### PR TITLE
AUT-132 - updates related to the locale settings:

### DIFF
--- a/src/main/java/ee/ria/sso/config/TaraConfiguration.java
+++ b/src/main/java/ee/ria/sso/config/TaraConfiguration.java
@@ -27,7 +27,9 @@ import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * @author Janar Rahumeel (CGI Estonia)
@@ -61,10 +63,9 @@ public class TaraConfiguration extends WebMvcConfigurerAdapter {
     public LocaleChangeInterceptor localeChangeInterceptor() {
         TaraLocaleChangeInterceptor localeInterceptor = new TaraLocaleChangeInterceptor();
         localeInterceptor.setIgnoreInvalidLocale(true);
-        String[] names = Arrays.asList(casProperties.getLocale().getParamName().split(","))
+        List<String> names = Arrays.asList(casProperties.getLocale().getParamName().split(","))
                 .stream()
-                .map(String::trim)
-                .toArray(String[]::new);
+                .map(String::trim).collect(Collectors.toList());
         localeInterceptor.setParamNames(names);
         log.info("Supported locale parameters: " + Arrays.asList(localeInterceptor.getParamNames()));
         return localeInterceptor;

--- a/src/main/java/ee/ria/sso/config/TaraOidcConfiguration.java
+++ b/src/main/java/ee/ria/sso/config/TaraOidcConfiguration.java
@@ -1,5 +1,6 @@
 package ee.ria.sso.config;
 
+import ee.ria.sso.i18n.TaraLocaleChangeInterceptor;
 import ee.ria.sso.oidc.*;
 import org.apache.http.HttpStatus;
 import org.apereo.cas.audit.AuditableExecution;
@@ -192,10 +193,10 @@ public class TaraOidcConfiguration {
     public FactoryBean<OidcServerDiscoverySettings> oidcServerDiscoverySettingsFactory() {
         return new OidcServerDiscoverySettingsFactory(casProperties) {
             @Override
-            public OidcServerDiscoverySettings getObject() {
+            public TaraOidcServerDiscoverySettings getObject() {
                 final OidcProperties oidc = casProperties.getAuthn().getOidc();
-                final OidcServerDiscoverySettings discoveryProperties =
-                        new OidcServerDiscoverySettings(casProperties, oidc.getIssuer());
+                final TaraOidcServerDiscoverySettings discoveryProperties =
+                        new TaraOidcServerDiscoverySettings(casProperties, oidc.getIssuer());
                 discoveryProperties.setClaimsSupported(oidc.getClaims());
                 discoveryProperties.setScopesSupported(oidc.getScopes());
                 discoveryProperties.setResponseTypesSupported(
@@ -205,6 +206,7 @@ public class TaraOidcConfiguration {
                 discoveryProperties.setGrantTypesSupported(
                         Collections.singletonList(OAuth20GrantTypes.AUTHORIZATION_CODE.getType()));
                 discoveryProperties.setIdTokenSigningAlgValuesSupported(Arrays.asList("none", "RS256"));
+                discoveryProperties.setUiLocalesSupported(TaraLocaleChangeInterceptor.SUPPORTED_LOCALE_PARAM_VALUES);
                 return discoveryProperties;
             }
         };

--- a/src/main/java/ee/ria/sso/oidc/TaraOidcServerDiscoverySettings.java
+++ b/src/main/java/ee/ria/sso/oidc/TaraOidcServerDiscoverySettings.java
@@ -1,0 +1,23 @@
+package ee.ria.sso.oidc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettings;
+
+import java.util.List;
+
+@Slf4j
+@Getter
+@Setter
+public class TaraOidcServerDiscoverySettings extends OidcServerDiscoverySettings {
+
+    @JsonProperty("ui_locales_supported")
+    private List<String> uiLocalesSupported;
+
+    public TaraOidcServerDiscoverySettings(final CasConfigurationProperties casProperties, final String issuer) {
+        super(casProperties, issuer);
+    }
+}

--- a/src/main/java/ee/ria/sso/service/idcard/OCSPValidator.java
+++ b/src/main/java/ee/ria/sso/service/idcard/OCSPValidator.java
@@ -67,6 +67,7 @@ public class OCSPValidator {
 
             OCSPResp response = this.sendOCSPReq(buildOCSPReq(certificateID, nonce), ocsp.getServiceUrl());
             BasicOCSPResp basicOCSPResponse = (BasicOCSPResp) response.getResponseObject();
+            Assert.notNull(basicOCSPResponse,"Invalid OCSP response! OCSP response object bytes could not be read!");
 
             validateResponseNonce(basicOCSPResponse, nonce);
             validateResponseSignature(basicOCSPResponse, ocsp.getTrustedCertificates());


### PR DESCRIPTION
* locale parameter values are treated as case-insensitive
* first valid value is used when more than one locale parameter value is specified
* supported locales are published at /oidc/.well-known/openid-configuration with the ui_locales_supported parameter

+ fix npe in case of malformed ocsp response