### PR TITLE
AUT-192 - add support for new scopes to selectively display auth methods

### DIFF
--- a/src/main/java/ee/ria/sso/authentication/AuthenticationType.java
+++ b/src/main/java/ee/ria/sso/authentication/AuthenticationType.java
@@ -1,23 +1,21 @@
 package ee.ria.sso.authentication;
 
+import ee.ria.sso.oidc.TaraScope;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/**
- * Created by Janar Rahumeel (CGI Estonia)
- */
 @Getter
 @AllArgsConstructor
 public enum AuthenticationType {
 
-    Default("", ""),
-    IDCard("idcard", "id-card"),
-    MobileID("mID", "mobile-id"),
-    eIDAS("eIDAS", "eidas"),
-    BankLink("banklink", "banklinks"),
-    SmartID("smartid", "smart-id");
+    Default("", "", null),
+    IDCard("idcard", "id-card", TaraScope.IDCARD),
+    MobileID("mID", "mobile-id", TaraScope.MID),
+    eIDAS("eIDAS", "eidas", TaraScope.EIDAS),
+    BankLink("banklink", "banklinks", TaraScope.BANKLINK),
+    SmartID("smartid", "smart-id", TaraScope.SMARTID);
 
     private final String amrName;
     private final String propertyName;
-
+    private final TaraScope scope;
 }

--- a/src/main/java/ee/ria/sso/config/TaraConfiguration.java
+++ b/src/main/java/ee/ria/sso/config/TaraConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -54,7 +55,7 @@ public class TaraConfiguration extends WebMvcConfigurerAdapter {
 
     @Bean
     public ThymeleafSupport thymeleafSupport(ManagerService managerService, CasConfigurationProperties casProperties, TaraProperties taraProperties) {
-        return new ThymeleafSupport(managerService, casProperties, taraProperties);
+        return new ThymeleafSupport(managerService, casProperties, taraProperties, getDefaultLocaleChangeParam());
     }
 
     @Bean
@@ -76,6 +77,11 @@ public class TaraConfiguration extends WebMvcConfigurerAdapter {
         localeInterceptor.setParamNames(names);
         log.info("Supported locale parameters: " + Arrays.asList(localeInterceptor.getParamNames()));
         return localeInterceptor;
+    }
+
+    private String getDefaultLocaleChangeParam() {
+        Optional<String> localeParam = Arrays.asList(casProperties.getLocale().getParamName().split(",")).stream().findFirst();
+        return localeParam.isPresent() ? localeParam.get() : TaraLocaleChangeInterceptor.DEFAULT_OIDC_LOCALE_PARAM;
     }
 
     @Configuration("TaraWebFlowConfiguration")

--- a/src/main/java/ee/ria/sso/config/TaraOidcConfiguration.java
+++ b/src/main/java/ee/ria/sso/config/TaraOidcConfiguration.java
@@ -231,10 +231,10 @@ public class TaraOidcConfiguration {
     }
 
     @Bean
-    public FilterRegistrationBean oidcAuthorizeCheckingServletFilter() {
+    public FilterRegistrationBean oidcAuthorizeCheckingServletFilter(OidcAuthorizeRequestValidator oidcAuthorizeRequestValidator) {
         final Map<String, String> initParams = new HashMap<>();
         final FilterRegistrationBean bean = new FilterRegistrationBean();
-        bean.setFilter(new OidcAuthorizeRequestValidationServletFilter());
+        bean.setFilter(new OidcAuthorizeRequestValidationServletFilter(oidcAuthorizeRequestValidator));
         bean.setUrlPatterns(Collections.singleton("/oidc/authorize"));
         bean.setInitParameters(initParams);
         bean.setName("oidcAuthorizeCheckingServletFilter");

--- a/src/main/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidationServletFilter.java
+++ b/src/main/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidationServletFilter.java
@@ -3,11 +3,9 @@ package ee.ria.sso.oidc;
 import ee.ria.sso.Constants;
 import ee.ria.sso.authentication.AuthenticationType;
 import ee.ria.sso.authentication.LevelOfAssurance;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.util.spring.ApplicationContextProvider;
-import org.springframework.context.ApplicationContext;
-import org.springframework.util.Assert;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -20,19 +18,18 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
+@AllArgsConstructor
 public class OidcAuthorizeRequestValidationServletFilter implements Filter {
 
-    private OidcAuthorizeRequestValidator oidcAuthorizeRequestValidator;
+    private final OidcAuthorizeRequestValidator oidcAuthorizeRequestValidator;
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        ApplicationContext ctx = ApplicationContextProvider.getApplicationContext();
-        Assert.notNull(ctx, "Spring context could not be found!");
-        this.oidcAuthorizeRequestValidator = ctx.getBean("oidcAuthorizeRequestValidator", OidcAuthorizeRequestValidator.class);
-        Assert.notNull(ctx, "OidcRequestValidator could not be not be found in Spring context!");
+        log.debug("Initialize filter: {}", OidcAuthorizeRequestValidationServletFilter.class.getName());
     }
 
     @Override
@@ -103,23 +100,38 @@ public class OidcAuthorizeRequestValidationServletFilter implements Filter {
         final String scope = request.getParameter(OidcAuthorizeRequestParameter.SCOPE.getParameterKey());
         if (StringUtils.isBlank(scope)) return Collections.emptyList();
 
+
+
         return Arrays.stream(scope.split(" "))
-                .map(s -> TaraScope.valueOf(s.toUpperCase()))
+                .map(s -> {
+                        try {
+                            return TaraScope.getScope(s);
+                        } catch (IllegalArgumentException e) {
+                            log.warn("Invalid scope value ignored!");
+                            return null;
+                        }
+                    })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 
     private List<AuthenticationType> getListOfAllowedAuthenticationMethods(final List<TaraScope> scopes) {
         if (scopes.contains(TaraScope.EIDASONLY)) {
             return Arrays.asList(AuthenticationType.eIDAS);
-        } else {
+        } else if (scopes.size() == 1 && scopes.contains(TaraScope.OPENID)) {
             return Arrays.stream(AuthenticationType.values())
                     .filter(e -> e != AuthenticationType.Default)
+                    .collect(Collectors.toList());
+        } else {
+            return Arrays.stream(AuthenticationType.values())
+                    .filter(e -> scopes.contains(e.getScope()) )
                     .collect(Collectors.toList());
         }
     }
 
     @Override
     public void destroy() {
+        log.debug("Destroy filter: {}", OidcAuthorizeRequestValidationServletFilter.class.getName());
     }
 
 }

--- a/src/main/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidator.java
+++ b/src/main/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidator.java
@@ -1,12 +1,9 @@
 package ee.ria.sso.oidc;
 
 import ee.ria.sso.authentication.LevelOfAssurance;
-import ee.ria.sso.flow.JSONFlowExecutionException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.services.ServicesManager;
-import org.apereo.cas.support.oauth.OAuth20GrantTypes;
 import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +12,7 @@ import org.springframework.util.Assert;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,19 +26,6 @@ public class OidcAuthorizeRequestValidator {
 
     @Autowired
     private ServicesManager servicesManager;
-
-    public static void checkGrantType(HttpServletRequest request) {
-        Optional<String> grantType = Optional.ofNullable(request.getParameter("grant_type"));
-        if (grantType.isPresent()) {
-            if (!OAuth20GrantTypes.AUTHORIZATION_CODE.getType().equals(grantType.get())) {
-                throw JSONFlowExecutionException.ofBadRequest(Collections.singletonMap("error", "unsupported_grant_type"),
-                        new RuntimeException("Unsupported grant type"));
-            }
-        } else {
-            throw JSONFlowExecutionException.ofBadRequest(Collections.singletonMap("error", "invalid_request"),
-                    new RuntimeException("No grant type found"));
-        }
-    }
 
     public void validateAuthenticationRequestParameters(final HttpServletRequest request) {
 
@@ -118,16 +100,8 @@ public class OidcAuthorizeRequestValidator {
 
         if (scopes.isEmpty() || !scopes.contains(TaraScope.OPENID.getFormalName())) {
             throw new InvalidRequestException(OidcAuthorizeRequestParameter.SCOPE, "invalid_scope", String.format(
-                    "Required scope <%s> not provided. TARA do not allow this request to be processed",
+                    "Required scope <%s> not provided",
                     TaraScope.OPENID.getFormalName()
-            ));
-        }
-
-        List<String> allowedScopes = Stream.of(TaraScope.values()).map(TaraScope::getFormalName).collect(Collectors.toList());
-        if (!ListUtils.subtract(scopes, allowedScopes).isEmpty()) {
-            throw new InvalidRequestException(OidcAuthorizeRequestParameter.SCOPE, "invalid_scope", String.format(
-                    "One or some of the provided scopes are not allowed by TARA, only <%s> are permitted. TARA do not allow this request to be processed",
-                    allowedScopes.stream().collect(Collectors.joining(", "))
             ));
         }
     }
@@ -136,7 +110,7 @@ public class OidcAuthorizeRequestValidator {
         String responseType = request.getParameter(OidcAuthorizeRequestParameter.RESPONSE_TYPE.getParameterKey());
         if (!"code".equals(responseType)) {
             throw new InvalidRequestException(OidcAuthorizeRequestParameter.RESPONSE_TYPE, "unsupported_response_type", String.format(
-                    "Provided response type is not allowed by TARA, only <%s> is permitted. TARA do not allow this request to be processed", "code"
+                    "Provided response type is not allowed by TARA, only <%s> is permitted", "code"
             ));
         }
     }
@@ -150,7 +124,7 @@ public class OidcAuthorizeRequestValidator {
 
             if (!allowedValues.contains(acrValues)) {
                 throw new InvalidRequestException(OidcAuthorizeRequestParameter.ACR_VALUES, "unsupported_acr_values", String.format(
-                        "Provided acr_values is not allowed by TARA, only <%s> are permitted. TARA do not allow this request to be processed",
+                        "Provided acr_values is not allowed by TARA, only <%s> are permitted",
                         allowedValues.stream().collect(Collectors.joining(", ")
                         )));
             }

--- a/src/main/java/ee/ria/sso/oidc/TaraScope.java
+++ b/src/main/java/ee/ria/sso/oidc/TaraScope.java
@@ -1,23 +1,27 @@
 package ee.ria.sso.oidc;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum TaraScope {
 
-    OPENID("openid", true),
-    EIDASONLY("eidasonly", false);
+    OPENID("openid"),
+    IDCARD("idcard"),
+    MID("mid"),
+    EIDAS("eidas"),
+    BANKLINK("banklink"),
+    SMARTID("smartid"),
+    EIDASONLY("eidasonly");
 
     private String formalName;
-    private boolean required;
 
-    TaraScope(String formalName, boolean required) {
-        this.formalName = formalName;
-        this.required = required;
-    }
+    public static TaraScope getScope(String value) {
+        for(TaraScope v : values())
+            if(v.formalName.equals(value))
+                return v;
 
-    public String getFormalName() {
-        return this.formalName;
-    }
-
-    public boolean isRequired() {
-        return this.required;
+        throw new IllegalArgumentException();
     }
 }

--- a/src/test/java/ee/ria/sso/config/ThymeleafSupportTest.java
+++ b/src/test/java/ee/ria/sso/config/ThymeleafSupportTest.java
@@ -6,20 +6,25 @@ import ee.ria.sso.authentication.AuthenticationType;
 import ee.ria.sso.flow.ThymeleafSupport;
 import ee.ria.sso.service.manager.ManagerService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.CasServerProperties;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.webflow.core.collection.SharedAttributeMap;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
 
 public class ThymeleafSupportTest extends AbstractTest {
 
@@ -53,27 +58,38 @@ public class ThymeleafSupportTest extends AbstractTest {
     }
 
     @Test
-    public void isAuthMethodAllowedShouldReturnFalseWhenMethodsDisabledButAllowedInSession() {
-        final ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null,
-                casProperties, taraProperties);
+    public void isAuthMethodAllowedWhenNoAttrSetInSession() {
         Arrays.stream(AuthenticationType.values()).filter(at -> at != AuthenticationType.Default)
                 .forEach(method -> {
+                    Mockito.when(taraProperties.isPropertyEnabled(Mockito.eq(method.getPropertyName()+ ".enabled"))).thenReturn(true);
+                    setRequestContextWithSessionMap(new HashMap<>());
+                    Assert.assertTrue("Method " + method + " should be allowed", this.thymeleafSupport.isAuthMethodAllowed(method));
+                });
+    }
+
+    @Test
+    public void isAuthMethodAllowedShouldReturnFalseWhenMethodsDisabledButAllowedInSession() {
+        final ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null,
+                casProperties, taraProperties, null);
+        Arrays.stream(AuthenticationType.values()).filter(at -> at != AuthenticationType.Default)
+                .forEach(method -> {
+                    Mockito.when(taraProperties.isPropertyEnabled(Mockito.eq(method.getPropertyName()+ ".enabled"))).thenReturn(false);
                     setRequestContextWithSessionMap(Collections.singletonMap(
                             Constants.TARA_OIDC_SESSION_AUTH_METHODS, Collections.singletonList(method)
                     ));
-                    Assert.assertFalse(thymeleafSupport.isAuthMethodAllowed(method));
+                    Assert.assertFalse("Method " + method + " should not be allowed", thymeleafSupport.isAuthMethodAllowed(method));
                 });
     }
 
     @Test
     public void isAuthMethodAllowedShouldReturnFalseWhenMethodsDisabledAndNotAllowedInSession() {
         final ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null,
-                casProperties, taraProperties);
+                casProperties, taraProperties, null);
         setRequestContextWithSessionMap(Collections.singletonMap(
                 Constants.TARA_OIDC_SESSION_AUTH_METHODS, Collections.emptyList()
         ));
         Arrays.stream(AuthenticationType.values()).filter(at -> at != AuthenticationType.Default)
-                .forEach(method -> Assert.assertFalse(thymeleafSupport.isAuthMethodAllowed(method)));
+                .forEach(method -> Assert.assertFalse("Method " + method + " should be allowed", thymeleafSupport.isAuthMethodAllowed(method)));
     }
 
     @Test
@@ -91,7 +107,7 @@ public class ThymeleafSupportTest extends AbstractTest {
         Mockito.when(managerService.getServiceByID("https://client/url"))
                 .thenReturn(Optional.of(oidcRegisteredService));
 
-        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(managerService, null, null);
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(managerService, null, null, null);
 
         setRequestContextWithSessionMap(
                 Collections.singletonMap(Constants.TARA_OIDC_SESSION_REDIRECT_URI, "https://client/url")
@@ -105,15 +121,77 @@ public class ThymeleafSupportTest extends AbstractTest {
         Mockito.when(managerService.getServiceByID("https://client/url"))
                 .thenReturn(Optional.empty());
 
-        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(managerService, casProperties, null);
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(managerService, casProperties, null, null);
 
-        setRequestContextWithSessionMap(
-                Collections.singletonMap(Constants.TARA_OIDC_SESSION_REDIRECT_URI, "https://client/url")
-        );
+        setRequestContextWithSessionMap(Collections.singletonMap(Constants.TARA_OIDC_SESSION_REDIRECT_URI, "https://client/url"));
         Assert.assertEquals("#", thymeleafSupport.getHomeUrl());
     }
 
+    @Test
+    public void getLocaleUrlShouldReturn() throws Exception {
+        setRequestContextWithSessionMap(new HashMap<>());
+
+        casProperties.getServer().setName("https://example.tara.url");
+
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, casProperties, null, "somelocaleparam");
+        Assert.assertEquals("https://example.tara.url:443?somelocaleparam=et", thymeleafSupport.getLocaleUrl("et"));
+    }
+
+    @Test
+    public void getBackUrlShouldReturnPac4jRequestedUrlWithSpecifiedLocale() throws Exception {
+        setRequestContextWithSessionMap(new HashMap<>());
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, casProperties, null, "somelocaleparam");
+        Assert.assertEquals("https://example.tara.ee?somelocaleparam=et", thymeleafSupport.getBackUrl("https://example.tara.ee", Locale.forLanguageTag("et")));
+    }
+
+    @Test
+    public void getBackUrlShouldReturnHashTagWhenEmpty() throws Exception {
+        setRequestContextWithSessionMap(new HashMap<>());
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, casProperties, null, "somelocaleparam");
+        Assert.assertEquals("#", thymeleafSupport.getBackUrl("", Locale.forLanguageTag("et")));
+        Assert.assertEquals("#", thymeleafSupport.getBackUrl("          ", Locale.forLanguageTag("et")));
+        Assert.assertEquals("#", thymeleafSupport.getBackUrl(null, Locale.forLanguageTag("et")));
+    }
+
+    @Test
+    public void isNotLocaleShouldReturnTrue() {
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, null, null, null);
+        Assert.assertTrue(thymeleafSupport.isNotLocale("en", Locale.forLanguageTag("et")));
+        Assert.assertTrue(thymeleafSupport.isNotLocale("xxx", Locale.forLanguageTag("et")));
+    }
+
+    @Test
+    public void isNotLocaleShouldReturnFalse() {
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, null, null, null);
+        Assert.assertFalse(thymeleafSupport.isNotLocale("ET", Locale.forLanguageTag("et")));
+        Assert.assertFalse(thymeleafSupport.isNotLocale("et", Locale.forLanguageTag("et")));
+    }
+
+    @Test
+    public void getTestEnvironmentAlertMessageIfAvailableShouldReturnProperyValue() {
+        String testMessage = "test123";
+        Mockito.when(taraProperties.getTestEnvironmentWarningMessage()).thenReturn(testMessage);
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, null, taraProperties, null);
+        Assert.assertEquals(testMessage, thymeleafSupport.getTestEnvironmentAlertMessageIfAvailable());
+    }
+
+    @Test
+    public void getTestEnvironmentAlertMessageIfAvailableShouldReturnNull() {
+        Mockito.when(taraProperties.getTestEnvironmentWarningMessage()).thenReturn(null);
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, null, taraProperties, null);
+        Assert.assertEquals(null, thymeleafSupport.getTestEnvironmentAlertMessageIfAvailable());
+    }
+
+    @Test
+    public void getCurrentRequestIdentifierShouldReturnIdFromMDC() {
+        String uniqueRequestId = UUID.randomUUID().toString();
+        MDC.put(Constants.MDC_ATTRIBUTE_REQUEST_ID, uniqueRequestId);
+        ThymeleafSupport thymeleafSupport = new ThymeleafSupport(null, null, taraProperties, null);
+        Assert.assertEquals(uniqueRequestId, thymeleafSupport.getCurrentRequestIdentifier());
+    }
+
     private static void setRequestContextWithSessionMap(final Map<String, Object> sessionMap) {
+        mockSpringServletRequestAttributes();
         final MockRequestContext requestContext = new MockRequestContext();
         final MockExternalContext externalContext = new MockExternalContext();
         final SharedAttributeMap<Object> map = externalContext.getSessionMap();
@@ -122,8 +200,15 @@ public class ThymeleafSupportTest extends AbstractTest {
                 (k, v) -> map.put(k, v)
         );
 
+        externalContext.setNativeRequest(new MockHttpServletRequest());
         requestContext.setExternalContext(externalContext);
         RequestContextHolder.setRequestContext(requestContext);
+    }
+
+    private static void mockSpringServletRequestAttributes() {
+        HttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
     }
 
 }

--- a/src/test/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidationServletFilterTest.java
+++ b/src/test/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidationServletFilterTest.java
@@ -3,10 +3,6 @@ package ee.ria.sso.oidc;
 import ee.ria.sso.Constants;
 import ee.ria.sso.authentication.AuthenticationType;
 import ee.ria.sso.authentication.LevelOfAssurance;
-import ee.ria.sso.oidc.OidcAuthorizeRequestValidationServletFilter;
-import ee.ria.sso.oidc.OidcAuthorizeRequestParameter;
-import ee.ria.sso.oidc.OidcAuthorizeRequestValidator;
-import ee.ria.sso.oidc.TaraScope;
 import org.apereo.cas.util.spring.ApplicationContextProvider;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -36,18 +32,13 @@ public class OidcAuthorizeRequestValidationServletFilterTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Mock
-    private ApplicationContext applicationContext;
-
-    @Mock
     private OidcAuthorizeRequestValidator oidcRequestValidator;
 
     private OidcAuthorizeRequestValidationServletFilter servletFilter;
 
     @Before
     public void setUp() throws Exception {
-        new ApplicationContextProvider().setApplicationContext(applicationContext);
-        Mockito.when(applicationContext.getBean(Mockito.eq("oidcAuthorizeRequestValidator"), Mockito.any(Class.class))).thenReturn(oidcRequestValidator);
-        servletFilter = new OidcAuthorizeRequestValidationServletFilter();
+        servletFilter = new OidcAuthorizeRequestValidationServletFilter(oidcRequestValidator);
         servletFilter.init(Mockito.mock(FilterConfig.class));
     }
 
@@ -125,7 +116,71 @@ public class OidcAuthorizeRequestValidationServletFilterTest {
     }
 
     @Test
+    public void assertAllAuthMethodsInSession() throws Exception {
+        assertAllAuthMethodsInSession(TaraScope.OPENID.getFormalName());
+        assertAllAuthMethodsInSession(String.join(" ", TaraScope.OPENID.getFormalName(), "unkonwn"));
+        assertAllAuthMethodsInSession(String.join(" ", TaraScope.OPENID.getFormalName(), "IDCARD"));
+        assertAllAuthMethodsInSession(String.join(" ", TaraScope.OPENID.getFormalName() ,
+                TaraScope.IDCARD.getFormalName(),
+                TaraScope.MID.getFormalName(),
+                TaraScope.EIDAS.getFormalName(),
+                TaraScope.BANKLINK.getFormalName(),
+                TaraScope.SMARTID.getFormalName()));
+    }
+
+    @Test
+    public void assertSingleAuthMethodsInSession() throws Exception {
+        for (AuthenticationType authenticationType : Arrays.stream(AuthenticationType.values()).filter(e -> e != AuthenticationType.Default).collect(Collectors.toList())) {
+
+            String scope = authenticationType.getScope().getFormalName();
+
+            assertAuthMethodInSession("Assert single scope",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope),
+                    authenticationType
+            );
+
+            assertAuthMethodInSession("Assert invalid scope is ignored",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope, "unknown"),
+                    authenticationType
+            );
+
+            assertAuthMethodInSession("Assert redundant scope is ignored",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope, scope),
+                    authenticationType
+            );
+        }
+    }
+
+    @Test
+    public void assertSelectionOfAuthMethodsInSession() throws Exception {
+            AuthenticationType authenticationType1 = AuthenticationType.IDCard;
+            AuthenticationType authenticationType2 = AuthenticationType.eIDAS;
+            String scope1 = authenticationType1.getScope().getFormalName();
+            String scope2 = authenticationType2.getScope().getFormalName();
+
+            assertAuthMethodInSession("Assert single occurrence of valid scope",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope1, scope2),
+                    authenticationType1,
+                    authenticationType2
+            );
+
+            assertAuthMethodInSession("Assert invalid scope is ignored",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope1, "unknown", scope2),
+                    authenticationType1,
+                    authenticationType2
+            );
+
+            assertAuthMethodInSession("Assert redundant scope is ignored",
+                    String.join(" ", TaraScope.OPENID.getFormalName(), scope1, scope1, scope2, scope2, scope2),
+                    authenticationType1,
+                    authenticationType2
+            );
+    }
+
+
+    @Test
     public void assertAllAuthMethodsInSessionWhenValidationSucceedsAndOnlyOpenidScopeProvided() throws Exception {
+
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addParameter(OidcAuthorizeRequestParameter.SCOPE.getParameterKey(),
                 TaraScope.OPENID.getFormalName()
@@ -138,17 +193,23 @@ public class OidcAuthorizeRequestValidationServletFilterTest {
         );
     }
 
+
+
     @Test
     public void assertOnlyEidasAuthMethodInSessionWhenValidationSucceedsAndEidasonlyScopeProvided() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter(OidcAuthorizeRequestParameter.SCOPE.getParameterKey(),
-                Arrays.asList(TaraScope.OPENID, TaraScope.EIDASONLY).stream()
-                        .map(s -> s.getFormalName()).collect(Collectors.joining(" "))
+        assertAuthMethodInSession("Assert single occurrence of valid scope",
+                String.join(" ", TaraScope.OPENID.getFormalName(), TaraScope.EIDASONLY.getFormalName()),
+                AuthenticationType.eIDAS
         );
 
-        servletFilter.doFilter(request, new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
-        Assert.assertEquals(Arrays.asList(AuthenticationType.eIDAS),
-                request.getSession(false).getAttribute(Constants.TARA_OIDC_SESSION_AUTH_METHODS)
+        assertAuthMethodInSession("Assert eidasonly overrides all other auth selection scopes",
+                String.join(" ", TaraScope.OPENID.getFormalName(), TaraScope.EIDASONLY.getFormalName(), TaraScope.EIDAS.getFormalName()),
+                AuthenticationType.eIDAS
+        );
+
+        assertAuthMethodInSession("Assert eidasonly overrides eidas",
+                String.join(" ", TaraScope.OPENID.getFormalName(), TaraScope.EIDASONLY.getFormalName(), TaraScope.IDCARD.getFormalName()),
+                AuthenticationType.eIDAS
         );
     }
 
@@ -183,6 +244,29 @@ public class OidcAuthorizeRequestValidationServletFilterTest {
         List<OidcAuthorizeRequestParameter> parameters = new ArrayList<OidcAuthorizeRequestParameter>(Arrays.asList(OidcAuthorizeRequestParameter.values()));
         parameters.removeAll(Arrays.asList(parametersToBeExcluded));
         return parameters.toArray(new OidcAuthorizeRequestParameter[parameters.size()]);
+    }
+
+
+    private void assertAllAuthMethodsInSession(String scopeValue) throws IOException, ServletException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(OidcAuthorizeRequestParameter.SCOPE.getParameterKey(), scopeValue);
+
+        servletFilter.doFilter(request, new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
+        Assert.assertEquals(
+                Arrays.asList(AuthenticationType.values()).stream().filter(at -> at != AuthenticationType.Default).collect(Collectors.toList()),
+                request.getSession(false).getAttribute(Constants.TARA_OIDC_SESSION_AUTH_METHODS)
+        );
+    }
+
+    private void assertAuthMethodInSession(String message, String scopeValue, AuthenticationType... authMethodInSession) throws IOException, ServletException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(OidcAuthorizeRequestParameter.SCOPE.getParameterKey(), scopeValue);
+
+        servletFilter.doFilter(request, new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
+        Assert.assertEquals(message,
+                Arrays.asList(authMethodInSession),
+                request.getSession(false).getAttribute(Constants.TARA_OIDC_SESSION_AUTH_METHODS)
+        );
     }
 
     @After

--- a/src/test/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidatorTest.java
+++ b/src/test/java/ee/ria/sso/oidc/OidcAuthorizeRequestValidatorTest.java
@@ -126,6 +126,32 @@ public class OidcAuthorizeRequestValidatorTest {
         oidcAuthorizeRequestValidator.validateAuthenticationRequestParameters(request);
     }
 
+    @Test
+    public void invalidScopeValueIsIgnored() {
+        MockHttpServletRequest request = new MockOidcRequestBuilder()
+                .addAllMandatoryParameters()
+                .addAllOptionalParameters()
+                .removeParameter("scope")
+                .addParameter("scope", "openid unknown")
+                .build();
+        oidcAuthorizeRequestValidator.validateAuthenticationRequestParameters(request);
+    }
+
+    @Test
+    public void openIdScopeValueIsMandatory() {
+        MockHttpServletRequest request = new MockOidcRequestBuilder()
+                .addAllMandatoryParameters()
+                .addAllOptionalParameters()
+                .removeParameter("scope")
+                .addParameter("scope", "eidasonly")
+                .build();
+
+        expectedEx.expect(OidcAuthorizeRequestValidator.InvalidRequestException.class);
+        expectedEx.expectMessage("Required scope <openid> not provided");
+
+        oidcAuthorizeRequestValidator.validateAuthenticationRequestParameters(request);
+    }
+
     public static class MockOidcRequestBuilder {
 
         MockHttpServletRequest httpServletRequest;

--- a/src/test/java/ee/ria/sso/service/idcard/OCSPValidatorTest.java
+++ b/src/test/java/ee/ria/sso/service/idcard/OCSPValidatorTest.java
@@ -240,7 +240,7 @@ public class OCSPValidatorTest {
         ocspResponseTransformer.setThisUpdateProvider(() -> {
             final Instant instant = Instant.now()
                     .plusSeconds(ocspConfiguration.getAcceptedClockSkew())
-                    .plusSeconds(1L);
+                    .plusSeconds(5L);
             return Date.from(instant);
         });
 


### PR DESCRIPTION
Changes:
* support for new scopes (idcard, mid, banklink, eidas, smartid)
* invalid scopes are ignored
* scopes are case sensitive
* add tests for ThymeleafSupport and fix the selection of locale param (instead of constant values, use the one from configuration).