### PR TITLE
Change initializeLoginForm success transition id

### DIFF
--- a/src/main/java/ee/ria/sso/flow/action/InitializeLoginAction.java
+++ b/src/main/java/ee/ria/sso/flow/action/InitializeLoginAction.java
@@ -4,6 +4,7 @@ import ee.ria.sso.Constants;
 import ee.ria.sso.authentication.credential.PreAuthenticationCredential;
 import ee.ria.sso.oidc.TaraScope;
 import ee.ria.sso.oidc.TaraScopeValuedAttribute;
+import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.springframework.stereotype.Component;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.Event;
@@ -22,7 +23,7 @@ public class InitializeLoginAction extends AbstractAction {
         if (isEidasOnlyAuthenticationForSpecificCountry(request, context)) {
             return new Event(this, "directEidasLogin");
         }
-        return new Event(this, "loginForm");
+        return new Event(this, CasWebflowConstants.TRANSITION_ID_SUCCESS);
     }
     
     private boolean isEidasOnlyAuthenticationForSpecificCountry(HttpServletRequest request, RequestContext context) {

--- a/src/main/webapp/WEB-INF/classes/webflow/login/login-webflow.xml
+++ b/src/main/webapp/WEB-INF/classes/webflow/login/login-webflow.xml
@@ -33,7 +33,7 @@
 	<action-state id="initializeLoginForm">
 		<evaluate expression="InitializeLoginAction" />
         <transition on="directEidasLogin" to="EIDASLoginStart"/>
-		<transition on="loginForm" to="viewLoginForm"/>
+		<transition on="success" to="viewLoginForm"/>
 	</action-state>
 
 	<view-state id="viewLoginForm" view="casLoginView" model="credential">

--- a/src/test/java/ee/ria/sso/flow/action/InitializeLoginActionTest.java
+++ b/src/test/java/ee/ria/sso/flow/action/InitializeLoginActionTest.java
@@ -5,6 +5,7 @@ import ee.ria.sso.authentication.credential.PreAuthenticationCredential;
 import ee.ria.sso.oidc.TaraScope;
 import ee.ria.sso.oidc.TaraScopeValuedAttribute;
 import ee.ria.sso.oidc.TaraScopeValuedAttributeName;
+import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -46,7 +47,7 @@ public class InitializeLoginActionTest {
         MockHttpSession mockHttpSession = new MockHttpSession();
         mockHttpSession.setAttribute(Constants.TARA_OIDC_SESSION_SCOPES, Arrays.asList(TaraScope.OPENID, TaraScope.EIDASONLY));
         Event event = action.doExecute(mockRequestContext(mockHttpSession));
-        assertEquals("loginForm", event.getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, event.getId());
     }
 
     @Test
@@ -55,7 +56,7 @@ public class InitializeLoginActionTest {
         mockHttpSession.setAttribute(Constants.TARA_OIDC_SESSION_SCOPES, Arrays.asList(TaraScope.OPENID, TaraScope.EIDASONLY));
 
         Event event = action.doExecute(mockRequestContext(mockHttpSession));
-        assertEquals("loginForm", event.getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, event.getId());
     }
 
     @Test
@@ -70,14 +71,14 @@ public class InitializeLoginActionTest {
         mockHttpSession.setAttribute(Constants.TARA_OIDC_SESSION_SCOPE_EIDAS_COUNTRY, eidasCountryAttribute);
 
         Event event = action.doExecute(mockRequestContext(mockHttpSession));
-        assertEquals("loginForm", event.getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, event.getId());
     }
 
     @Test
     public void scopeElementMissing_thenShowLoginForm() {
         MockHttpSession mockHttpSession = new MockHttpSession();
         Event event = action.doExecute(mockRequestContext(mockHttpSession));
-        assertEquals("loginForm", event.getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, event.getId());
     }
 
     private RequestContext mockRequestContext(MockHttpSession mockHttpSession) {


### PR DESCRIPTION
CAS webflows are expecting to find transition with `success` id in `initializeLoginForm` state. For example [SPNEGO webflow](https://github.com/apereo/cas/blob/525153eeb5860ad3dca9072664d8d8d6f3625295/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpnegoWebflowConfigurer.java#L44).